### PR TITLE
Add cross-compile instruction for Windows, and fresh-how-to instruction

### DIFF
--- a/c/SimpleDemo/FRESH-CREATE.md
+++ b/c/SimpleDemo/FRESH-CREATE.md
@@ -1,0 +1,28 @@
+# How to freshly create your own custom module
+
+In case you start off by your own, and not start with this SimpleDemo project, follow along with the following guide to be able to create your own custom module ready for dynamically loaded by Godot 3.0.
+
+1. Compile and build a share/dynamic library of your custom module. You can just use `simple.c` file as a starting point.
+2. Open Godot 3.0
+3. Create a new resource for "NativeScript".
+4. Look at its Inspector panel.
+5. Click "Save as" then select where you would like to save it at. It will have `.gdns` extension. Reccommend to create a new directory, then save all things in that directory.
+6. You will notice `Path` has been set properly after we saved it.
+7. Click on `<null>` value of `Library` property then select `New GDNativeLibrary`.
+8. Click on it again to edit it.
+9. Click on 'Save as' then enter the file name, and change its extension to `.gdnlib` for ease of remember and we will know it immediately that this is `GDNativeLibrary` stuff.
+10. Currently there is no UI to edit shared library path for `GDNativeLibrary` resource. What we will do is to take a look at `bin/simple.gdnlib` of SimpleDemo project then copy its `[entry]` and `[dependencies]` sections to your `.gdnlib` file. You also have to edit this file via any of text editor outside of Godot 3.0. You can't edit this with Godot editor as it won't let you see anything.
+11. Inside your `.gdnlib`, enter relevant path for your shared libraries for all platforms. Mainly `X11.64`, `Windows.64`, and `OSX.64`. Use format `res://` and enter correct path to each one.
+12. Back to your `.gdns` by clicking on it. **This is important**. Enter a correct `Class Name` that you refer to in your C source file. If you enter it incorrectly, Godot won't be able to load your module. Then click 'Save'.
+13. Now you can go back to your normal script then use the following code to load it.
+    
+    ```
+    onready var my_custom_module = preload("res://PATH/TO/YOUR/MODULE/your_module.gdns")
+
+    func _ready():
+        my_custom_module.method_1()
+    ```
+
+    You then can use its methods normally.
+
+Becareful when you try to save any changes made for `NativeScript` and `GDNativeLibrary` resource in Inspector panel. Sometimes it is lost due to it won't effectively save (hopefully it will be fixed). Better to confirm saving is to click on `Save`.

--- a/c/SimpleDemo/README.md
+++ b/c/SimpleDemo/README.md
@@ -38,12 +38,53 @@ On Mac OS X:
 This creates the file 'libsimple.dylib' as a universal binary (or alternatively remove one of the -arch options from both commands if you want to just compile for one architecture).
 
 ### Windows
-To be added
+Cross-compile from macOS
+
+You first need to install `mingw-w64` by executing the following command
+
+    brew install mingw-w64
+
+Please see [this](http://docs.godotengine.org/en/stable/development/compiling/compiling_for_windows.html#cross-compiling-for-windows-from-other-operating-systems) for instruction on how to test that you have installed it successfully. In short and general, you would be able to execute
+
+    x86_64-w64-mingw32-gcc --version
+
+Then if it shows version as output, you're good to go!
+
+Next
+
+    cd src
+    x86_64-w64-mingw32-gcc -c -Wall -Werror -fpic simple.c
+    x86_64-w64-mingw32-gcc -shared -o simple.dll -I/PATH/TO/GODOT/HEADERS
+
+This will create `simple.o` at the same directory as `simple.c` then create a shared library that could be loaded dynamically at `bin/simple.dll`.
+
+> Please note that for Windows we use `simple.dll` **not** `libsimple.dll` as this name is pre-set in `bin/simple.gdnlib`. Anyway, whichever name is ok to use.
+    
 
 ## Usage
 
-Create a new object using `load("res://SIMPLE.gdns").new()`
+Create a new object using `load("res://bin/simple.gdns").new()`
 
 This object has following methods you can use:
  * `get_data()`
 
+For example
+
+```
+onready var data = preload("res://bin/simple.gdns").new()
+
+func _ready():
+    print(data)
+```
+
+You should see `World from GDNative!` as output from console from within Godot editor!
+
+## Important Note
+
+`simple.c` is coded to refer to `SIMPLE` class name for our custom module. The project is already set to refer to that name for `bin/simple.gdnlib` (see its inspector panel).
+
+If you create your own custom module and specify wrong name different from what you use inside C source code, then Godot won't be able to load your module.
+
+## How to freshly create your own custom module
+
+See [FRESH-CREATE.md](https://github.com/haxpor/GDNative-demos/blob/master/c/SimpleDemo/FRESH-CREATE.md) for instructions.


### PR DESCRIPTION
* Added Windows (cross-compile from macOS) mingw's compilation parameters for SimpleDemo.
* Added a few important notes regarding steps to create/load custom module in Godot 3.0
* Added a fresh instruction on how to create a custom module from scratch for Godot 3.0 (preview [here](https://github.com/haxpor/GDNative-demos/blob/patch-1/c/SimpleDemo/FRESH-CREATE.md) on my patch-1 branch)

PS. Happy to know that custom module creation can be done entirely on platform you're currently have i.e. macOS or others. I do believe Godot 3.0 would add more productivity to users.