### PR TITLE
Add Linux support to simple C++ demo and add ability for SimpleSprite to move as intended 

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -10,4 +10,3 @@
 [submodule "cpp/simple/godot-cpp"]
 	path = cpp/simple/godot-cpp
 	url = https://github.com/godotengine/godot-cpp.git
-

--- a/cpp/simple/Makefile
+++ b/cpp/simple/Makefile
@@ -1,2 +1,0 @@
-all:
-	scons cpp_bindings="../../godot-cpp/" headers="../../godot-cpp/godot_headers/"

--- a/cpp/simple/SConstruct
+++ b/cpp/simple/SConstruct
@@ -18,9 +18,32 @@ opts.Add(BoolVariable("use_llvm", "Use the LLVM / Clang compiler", "no"))
 opts.Add(PathVariable("target_path", "The path where the lib is installed.", "project/gdnative/"))
 opts.Add(PathVariable("target_name", "The library name.", "libsimple", PathVariable.PathAccept))
 
+# Updates the environment with the option variables.
 opts.Update(env)
 
-if ARGUMENTS.get("use_llvm", "no") == "yes":
+# Process platform arguments. Here we use the same names as GDNative.
+if env["p"] != "":
+    env["platform"] = env["p"]
+
+if env["platform"] == "macos":
+    env["platform"] = "osx"
+elif env["platform"] in ("x11", "linuxbsd"):
+    env["platform"] = "linux"
+elif env["platform"] == "bsd":
+    env["platform"] = "freebsd"
+
+if env["platform"] == "":
+    print("No valid target platform selected.")
+    quit()
+
+platform = env["platform"]
+
+# Process other arguments.
+if env["platform"] == "osx" and not env["use_llvm"]:
+    env["use_llvm"] = "yes"
+
+if env["use_llvm"] == "yes":
+    env["CC"] = "clang"
     env["CXX"] = "clang++"
 
 # put stuff that is the same for all first, saves duplication
@@ -48,6 +71,8 @@ elif env["platform"] == "windows":
         env.Append(CCFLAGS=["-EHsc", "-D_DEBUG", "-MDd"])
     else:
         env.Append(CCFLAGS=["-O2", "-EHsc", "-DNDEBUG", "-MD"])
+
+SConscript("godot-cpp/SConstruct")
 
 
 def add_sources(sources, dir):

--- a/cpp/simple/project/gdnative/linux/.gitignore
+++ b/cpp/simple/project/gdnative/linux/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/cpp/simple/project/gdnative/osx/.gitignore
+++ b/cpp/simple/project/gdnative/osx/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/cpp/simple/project/gdnative/simple.gdnlib
+++ b/cpp/simple/project/gdnative/simple.gdnlib
@@ -8,7 +8,11 @@ reloadable=true
 [entry]
 
 Windows.64="res://gdnative/windows/libsimple.dll"
+X11.64="res://gdnative/linux/libsimple.so"
+OSX.64="res://gdnative/osx/libsimple.dylib"
 
 [dependencies]
 
 Windows.64=[  ]
+X11.64=[  ]
+OSX.64=[  ]

--- a/cpp/simple/project/gdnative/simple_sprite.gdns
+++ b/cpp/simple/project/gdnative/simple_sprite.gdns
@@ -1,0 +1,9 @@
+[gd_resource type="NativeScript" load_steps=2 format=2]
+
+[ext_resource path="res://gdnative/simple.gdnlib" type="GDNativeLibrary" id=1]
+
+[resource]
+
+resource_name = "SimpleSprite"
+class_name = "SimpleSprite"
+library = ExtResource( 1 )

--- a/cpp/simple/project/gdnative/windows/.gitignore
+++ b/cpp/simple/project/gdnative/windows/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/cpp/simple/project/main.tscn
+++ b/cpp/simple/project/main.tscn
@@ -1,7 +1,8 @@
-[gd_scene load_steps=3 format=2]
+[gd_scene load_steps=4 format=2]
 
 [ext_resource path="res://main.gd" type="Script" id=1]
 [ext_resource path="res://icon.png" type="Texture" id=2]
+[ext_resource path="res://gdnative/simple_sprite.gdns" type="Script" id=3]
 
 [node name="Node" type="Node"]
 script = ExtResource( 1 )
@@ -19,8 +20,12 @@ margin_top = 360.0
 margin_right = 662.0
 margin_bottom = 374.0
 align = 1
+__meta__ = {
+"_edit_use_anchors_": false
+}
 
 [node name="Sprite" type="Sprite" parent="."]
 texture = ExtResource( 2 )
+script = ExtResource( 3 )
 
 [connection signal="pressed" from="Button" to="." method="_on_Button_pressed"]

--- a/cpp/simple/src/Simple.cpp
+++ b/cpp/simple/src/Simple.cpp
@@ -18,25 +18,17 @@ void SimpleSprite::_register_methods() {
 	godot::register_method("_process", &SimpleSprite::_process);
 }
 
+// `_init` doesn't need to be registered in `_register_methods`.
 void SimpleSprite::_init() {
-	godot::Godot::print("Wheeeeey");
+	godot::Godot::print("A SimpleSprite was initialized in GDNative!");
 }
 
 void SimpleSprite::_process(double delta) {
+	godot::Input *input = godot::Input::get_singleton();
 	godot::Vector2 input_dir(0, 0);
 
-	if (godot::Input::get_singleton()->is_action_pressed("ui_right")) {
-		input_dir.x += 1;
-	}
-	if (godot::Input::get_singleton()->is_action_pressed("ui_left")) {
-		input_dir.x -= 1;
-	}
-	if (godot::Input::get_singleton()->is_action_pressed("ui_down")) {
-		input_dir.y += 1;
-	}
-	if (godot::Input::get_singleton()->is_action_pressed("ui_up")) {
-		input_dir.y -= 1;
-	}
+	input_dir.x = input->get_action_strength("ui_right") - input->get_action_strength("ui_left");
+	input_dir.y = input->get_action_strength("ui_down") - input->get_action_strength("ui_up");
 
 	set_position(get_position() + input_dir.normalized() * delta * 300);
 }


### PR DESCRIPTION
This PR adds Linux support to the reworked demo in #51.

Mac "should" also work, but when I try to build, it fails to build `godot-cpp` due to there being too many warnings.