### PR TITLE
Update README to document versioned branches

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,13 +5,28 @@ Each folder inside of those is a GDNative project. Once compiled, the
 `project.godot` file can be opened with
 [Godot Engine](https://godotengine.org), the open source 2D and 3D game engine.
 
+**Important:** Each demo depends on submodules for the `godot-headers` and
+`godot-cpp` GDNative dependencies. You should initialize this repository by
+checking out the submodules recursively:
+
+```
+git submodule update --init --recursive
+```
+
 For non-GDNative demos (GDScript, VisualScript, and C#), please see the
 [Godot demo projects](https://github.com/godotengine/godot-demo-projects/) repo.
 
 ## Godot versions
 
-The [`master`](https://github.com/godotengine/gdnative-demos) branch
-is compatible with the latest stable Godot version (currently 3.3).
+The [`master`](https://github.com/godotengine/gdnative-demos/tree/master) branch
+is compatible with the `3.x` development branch of Godot.
+
+Numbered branches are compatible with the corresponding Godot branch.
+The following numbered branches are available:
+
+- [`3.3`](https://github.com/godotengine/gdnative-demos/tree/3.3)
+- [`3.4`](https://github.com/godotengine/gdnative-demos/tree/3.4)
+
 Older Godot versions are not supported by this repo.
 
 ## Useful links


### PR DESCRIPTION
And mention the need to initialize submodules.

---

Draft as it's pending on merging #62 that ports the demos to 3.4.3-stable.

I created the `3.3` branch already as a copy of current `master`. The `3.4` branch doesn't exist yet, I would create it once the above is merged (and we can then port demos to 3.5).